### PR TITLE
fix fetch_result

### DIFF
--- a/lib/Job/Machine/DB.pm
+++ b/lib/Job/Machine/DB.pm
@@ -189,7 +189,7 @@ sub fetch_result {
 	};
 	my $result = $self->select_first(sql => $sql,data => [$id]) || return;
 
-	return $self->serializer->deserialize($result->{result})->{data};
+	return $self->serializer->deserialize($result->{result});
 }
 
 sub fetch_results {

--- a/t/worker.t
+++ b/t/worker.t
@@ -45,7 +45,7 @@ sub process {
 	my $reply = "You've got nail";
 	ok($self->reply({data => $reply}), 'Talking to ourself');
 	ok($res = $client->receive($id),'- But do we listen?');
-	is($res, $reply,'- Did we hear what we said?');
+	is($res->{data}, $reply,'- Did we hear what we said?');
 	ok($client->uncheck($id),'Uncheck first message');
 };
 

--- a/t/worker.t
+++ b/t/worker.t
@@ -90,9 +90,18 @@ sub _worker : Test(98) {
 		XML::Simple
 		YAML
 	/) {
+		if ($serializer ne '<default>') {
+			my $class = "Data::Serializer::".$serializer;
+			eval "use $class";
+
+			if ($@) {
+				diag("$class not installed, skipping");
+				next;
+			}
+		}
 		my %config = main::config();
 		$config{serializer} = $serializer unless $serializer eq '<default>';
-		ok(my $worker = Worker->new(%config),'New Worker');
+		ok(my $worker = Worker->new(%config),'New Worker using '.$serializer);
 		isa_ok($worker,'Worker','Worker class');
 		is($worker->receive,undef,'receive loop');
 	}

--- a/t/worker_fail_if_hash_not_named_data.t
+++ b/t/worker_fail_if_hash_not_named_data.t
@@ -1,0 +1,119 @@
+package Worker;
+
+use strict;
+use warnings;
+use Test::More;
+
+use base 'Job::Machine::Worker';
+
+use Job::Machine::Client;
+
+our $id;
+sub data  {
+	return {
+		message => 'Try Our Tasty Foobar!',
+		number  => 1,
+		array   => [1,2,'three',],
+	};
+};
+
+sub timeout {5}
+
+sub keep_running {0}
+
+sub startup {
+	my ($self) = @_;
+	my %config = main::config();
+	ok(my $client = Job::Machine::Client->new(%config),'New client');
+	my $version = $client->db->dbh->{pg_server_version};
+	return if $version < 90000;
+
+	$self->{client} = $client;
+	ok($id = $client->send($self->data),'Send a task');
+	$config{queue} = 'q';
+	my $id2;
+	ok(my $client2 = Job::Machine::Client->new(%config),'Another client');
+	ok($id2 = $client2->send($self->data),'Send another task');
+	ok($client2->uncheck($id2),'Uncheck send message');
+}
+
+sub process {
+	my ($self, $task) = @_;
+	is_deeply($task->{data}, $self->data,'- Did we get what we sent?');
+	my $client = $self->{client};
+	is(my $res = $client->check($id),undef,'Check for no message') if $task->{name} eq 'qyouw';
+	my $reply = "You've got nail";
+	ok($self->reply({foo => $reply}), 'Talking to ourself');
+	ok($res = $client->receive($id),'- But do we listen?');
+	is($res->{foo}, $reply,'- Did we hear what we said?');
+	ok($client->uncheck($id),'Uncheck first message');
+};
+
+package Test::Job::Machine;
+
+use strict;
+use warnings;
+use base qw(Test::Class);
+use Test::More;
+
+sub db_name {'__jm::test__'};
+
+sub startup : Test(startup => 2) {
+	my $self = shift;
+	my $command = 'createdb -e '.db_name;
+	qx{$command} || return $self->{skip} = 1;
+
+	$command = 'psql '.db_name.'<sql/create_tables.sql';
+	ok(qx{$command},'Create Job::Machine tables') or return;
+	ok($self->{dbh} = DBI->connect('dbi:Pg:dbname='.db_name), 'Connect to test database') or return;
+};
+
+sub cleanup : Test(shutdown) {
+	my $self = shift;
+	return if $self->{skip};
+
+	$self->{dbh}->disconnect;
+	my $command = 'dropdb '.db_name;
+	qx{$command};
+};
+
+sub _worker : Test(98) {
+	my $self = shift;
+	return if $self->{skip};
+
+	for my $serializer (qw/
+		<default>
+		Config::General
+		Data::Dumper
+		JSON
+		Storable
+		XML::Simple
+		YAML
+	/) {
+		if ($serializer ne '<default>') {
+			my $class = "Data::Serializer::".$serializer;
+			eval "use $class";
+
+			if ($@) {
+				diag("$class not installed, skipping");
+				next;
+			}
+		}
+		my %config = main::config();
+		$config{serializer} = $serializer unless $serializer eq '<default>';
+		ok(my $worker = Worker->new(%config),'New Worker using '.$serializer);
+		isa_ok($worker,'Worker','Worker class');
+		is($worker->receive,undef,'receive loop');
+	}
+};
+
+package main;
+
+use strict;
+use warnings;
+
+sub config {
+	return (dsn => 'dbi:Pg:dbname=__jm::test__', queue => 'qyouw');
+}
+
+Test::Job::Machine->runtests;


### PR DESCRIPTION
It seems that calling ->{data} on the return value from
$self->serializer->deserialize($result->{result})
always returns nothing, because $result->{result} does not contain a
data-subhash.

At least I never got any data back when calling $client->receive($id).
After removing ->{data} I get data back.

I did not look too deep into the source, so I might have misunderstood
something. In this case I'd appreciate an explanation.

If this is indeed a bug, than please apply this patch.

Greeting,
domm
